### PR TITLE
add space between links in the navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,11 @@
-*, :after, :before {
+*,
+:after,
+:before {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
-html{
+html {
   scroll-behavior: smooth;
 }
 body {
@@ -33,6 +35,7 @@ nav {
 nav > ul {
   list-style: none;
   display: flex;
+  gap: 40px;
 }
 nav a {
   text-decoration: none;
@@ -65,7 +68,6 @@ h3 {
   background: linear-gradient(to top, #4776e6 0%, #8e54e9 74%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-
 }
 .description {
   display: flex;


### PR DESCRIPTION
## Fixes Issue #1

## Changes proposed were to add space between the links in the nav.

The problem was by adding a "gap:40px;" in the .nav > ul , since it already was a "display:flex;" there was no need to use "margin";

Below is a screenshot of the problem solved!

## Screenshots

<img width="1440" alt="Screen Shot 2022-09-24 at 13 28 50" src="https://user-images.githubusercontent.com/94648837/192095801-0ce567e3-933a-40c9-bac5-503cff1fac1f.png">



